### PR TITLE
Use __GLASGOW_HASKELL__ instead of MIN_VERSION_base

### DIFF
--- a/System/Lock/FLock.hsc
+++ b/System/Lock/FLock.hsc
@@ -5,7 +5,7 @@ module System.Lock.FLock
 
 import Control.Monad.Trans (MonadIO, liftIO)
 import Data.Bits ((.|.))
-#if MIN_VERSION_base(4,5,0)
+#if __GLASGOW_HASKELL__ > 702
 import Foreign.C.Types (CInt(..))
 #else
 import Foreign.C.Types (CInt)


### PR DESCRIPTION
Apparently `MIN_VERSION_XXX` macros support for hsc2hs was added to Cabal repo on Apr 27, 2011 (ghc/packages-Cabal@b24eca13a69e7257734b46b2d50576194f4d3a9c). But the current Haskell Platform hasn't  had the change yet.

We can use `__GLASGOW_HASKELL__` macro instead of `MIN_VERSION_base` here. If you use cabal-install which was built using the newer Cabal library (>= 1.12 or so), you can compile flock library without my fix, though.
