### PR TITLE
Alternative conservative interface

### DIFF
--- a/System/Lock/FLock.hsc
+++ b/System/Lock/FLock.hsc
@@ -1,6 +1,6 @@
 {-# LANGUAGE ForeignFunctionInterface, CPP, FlexibleContexts #-}
 module System.Lock.FLock
-      (withLock, lock, unlock,
+      (withLock, withFdLock, lock, lockFd, unlock,
        SharedExclusive(Shared, Exclusive), Block(Block, NoBlock), Lock) where
 
 import Control.Monad.IO.Class (MonadIO (..))
@@ -11,6 +11,7 @@ import Foreign.C.Types (CInt(..))
 import Foreign.C.Types (CInt)
 #endif
 import System.Posix.Error (throwErrnoPathIfMinus1_)
+import Foreign.C.Error (throwErrnoIfMinus1_)
 import System.Posix.IO (openFd, defaultFileFlags, closeFd,
                         OpenMode(ReadOnly, WriteOnly))
 import System.Posix.Types (Fd(Fd))
@@ -40,17 +41,34 @@ withLock fp se b x =
     unlock
     (const x)
 
+withFdLock :: (MonadIO m, MonadBaseControl IO m) => Fd -> SharedExclusive -> Block -> m a -> m a
+withFdLock fd se b x =
+  bracket
+    (lockFd fd se b)
+    unlock
+    (const x)
+
+operation :: SharedExclusive -> Block -> CInt
+operation se b = case b of
+                     Block -> op
+                     NoBlock -> op .|. c_LOCK_NB
+    where op = case se of
+                   Shared -> c_LOCK_SH
+                   Exclusive -> c_LOCK_EX
+
 lock :: MonadIO m => FilePath -> SharedExclusive -> Block -> m Lock
 lock fp se b = liftIO
              $ do Fd fd <- openFd fp om Nothing defaultFileFlags
-                  throwErrnoPathIfMinus1_ "flock" fp $ flock fd op'
+                  throwErrnoPathIfMinus1_ "flock" fp $ flock fd (operation se b)
                   return (Lock fd)
-    where (om, op) = case se of
-                         Shared -> (ReadOnly, c_LOCK_SH)
-                         Exclusive -> (WriteOnly, c_LOCK_EX)
-          op' = case b of
-                    Block -> op
-                    NoBlock -> op .|. c_LOCK_NB
+    where om = case se of
+                   Shared -> ReadOnly
+                   Exclusive -> WriteOnly
+
+lockFd :: MonadIO m => Fd -> SharedExclusive -> Block -> m Lock
+lockFd (Fd fd) se b = liftIO
+                    $ do throwErrnoIfMinus1_ "flock" $ flock fd (operation se b)
+                         return (Lock fd)
 
 unlock :: MonadIO m => Lock -> m ()
 unlock (Lock fd) = liftIO $ do _ <- flock fd c_LOCK_UN


### PR DESCRIPTION
Hey Erik,

The flock package currently does not merely wrap flock() conservatively, but also takes on responsibility for opening the file prior to obtaining a lock. Furthermore, when opening the file, it is hard-coded to open the file for writing when the caller requests an exclusive lock.

On Solaris, it is indeed the case that obtaining an exclusive lock requires a writable file. On Linux, however, this is not the case: there, it is perfectly possible to obtain an exclusive lock on a read-only file.

Consequently, the flock package is currently not usable when one needs an exclusive lock on a read-only file on Linux.

Unfortunately, this happens to be the precise use case that I have for flock() in my program (which only runs on Linux), which means I cannot phase out my own old ad-hoc flock() binding. :-(

One possible solution would be to make the flock package detect whether it is running on Solaris or not, and act accordingly.

However, it seems to me that for the flock package to stake a claim to being /the/ canonical flock binding, it simply also needs a /conservative/ wrapper around flock(), that doesn't assume additional responsibility for opening the file, and simply lets the user pass an existing file descriptor, removing the need for hairy platform-dependent choices altogether, and giving users direct access to the native flock() capabilities offered by their respective platforms.

The commit I am proposing adds such a conservative interface, in the form of two new functions: lockFd and withFdLock.

Cheers,

Eelis
