### PR TITLE
Use exceptions instead of monad-control

### DIFF
--- a/System/Lock/FLock.hsc
+++ b/System/Lock/FLock.hsc
@@ -13,9 +13,8 @@ module System.Lock.FLock
   , Lock
   ) where
 
-import Control.Exception.Lifted    ( bracket )
+import Control.Monad.Catch         ( MonadMask, bracket )
 import Control.Monad.IO.Class      ( MonadIO (..) )
-import Control.Monad.Trans.Control ( MonadBaseControl )
 import Data.Bits                   ( (.|.) )
 import Foreign.C.Error             ( throwErrnoIfMinus1Retry_ )
 #if __GLASGOW_HASKELL__ > 702
@@ -48,14 +47,14 @@ data Block = Block | NoBlock
 
 newtype Lock = Lock CInt
 
-withLock :: (MonadIO m, MonadBaseControl IO m) => FilePath -> SharedExclusive -> Block -> m a -> m a
+withLock :: (MonadIO m, MonadMask m) => FilePath -> SharedExclusive -> Block -> m a -> m a
 withLock fp se b x =
   bracket
     (lock fp se b)
     unlock
     (const x)
 
-withFdLock :: (MonadIO m, MonadBaseControl IO m) => Fd -> SharedExclusive -> Block -> m a -> m a
+withFdLock :: (MonadIO m, MonadMask m) => Fd -> SharedExclusive -> Block -> m a -> m a
 withFdLock fd se b x =
   bracket
     (lockFd fd se b)

--- a/flock.cabal
+++ b/flock.cabal
@@ -23,8 +23,7 @@ Source-repository head
 Library
   Build-Depends:      base > 3 && < 5
                     , transformers >= 0.2 && < 0.5
-                    , monad-control >= 0.3 && < 1.1
-                    , lifted-base >= 0.1 && < 0.3
+                    , exceptions >= 0.6 && < 0.9
                     , unix >= 2.3 && < 2.8
   Exposed-modules:    System.Lock.FLock
   GHC-Options:        -Wall


### PR DESCRIPTION
This change could be a bit controversial.

I've been using the exceptions package for packages that need just exception handling, whereas monad-control for further functionality like arbitrary control functions as described in http://www.yesodweb.com/blog/2014/06/exceptions-transformers.

The flock library depends on monad-control solely for exception handling. We could switch to exceptions.

What do you think?